### PR TITLE
fixes unexpected removal of blockquotes

### DIFF
--- a/src/tags/blockquote/index.js
+++ b/src/tags/blockquote/index.js
@@ -1,36 +1,39 @@
 class Blockquote {
-  constructor (quillJS) {
-    this.quillJS = quillJS
-    this.name = 'blockquote'
-    this.pattern = /^(>)\s/g
-    this.getAction.bind(this)
+  constructor(quillJS) {
+    this.quillJS = quillJS;
+    this.name = 'blockquote';
+    this.pattern = /^(>)\s/g;
+    this.getAction.bind(this);
   }
 
-  getAction () {
+  getAction() {
     return {
       name: this.name,
       pattern: this.pattern,
       action: (text, selection, pattern) => {
-        const match = pattern.exec(text)
-        if (!match) { return }
-        const originalText = match[0] || ''
+        const match = pattern.exec(text);
+        if (!match) {
+          return;
+        }
+        const originalText = match[0] || '';
         setTimeout(() => {
-          this.quillJS.formatText(selection.index, 1, 'blockquote', true)
-          this.quillJS.deleteText(selection.index - originalText.length, originalText.length)
-        }, 0)
+          this.quillJS.formatText(selection.index, 1, 'blockquote', true);
+          this.quillJS.deleteText(
+            selection.index - originalText.length,
+            originalText.length
+          );
+        }, 0);
       },
       release: () => {
         setTimeout(() => {
-          this.quillJS.format('blockquote', false)
-          const contentIndex = this.quillJS.getSelection().index
-          const beforeLine = this.quillJS.getLine(contentIndex - 1)[0]
-          if (beforeLine.domNode.textContent === '') {
-            beforeLine.format('blockquote', false)
-          }
-        }, 0)
-      }
-    }
+          const contentIndex = this.quillJS.getSelection().index;
+
+          const [, length] = this.quillJS.getLine(contentIndex);
+          if (length === 0) this.quillJS.format('blockquote', false);
+        }, 0);
+      },
+    };
   }
 }
 
-export default Blockquote
+export default Blockquote;


### PR DESCRIPTION
Stumbled upon a problem with editing content in blockquotes. Steps to reproduce:

1. Insert a blockquote.
2. Use backspace to remove a character.
3. Instead of freely editing the quote - it's been replaced with a normal paragraph.

Keep up with the good work @cloverhearts 💪 