### PR TITLE
Allow change regex patterns and ignore tags with option param.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -16,8 +16,8 @@ class MarkdownActivity {
       tilde: '~',
       underscore: '_'
     }
-    this.ignoreTags = ['PRE']
-    this.tags = new TagsOperators(this.quillJS)
+    this.ignoreTags = options.ignoreTags || ['PRE']
+    this.tags = new TagsOperators(this.quillJS, options.tags)
     this.matches = this.tags.getOperatorsAll()
     this.fullMatches = this.tags.getFullTextOperatorsAll()
   }

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import 'regenerator-runtime/runtime'
 import TagsOperators from './tags'
 
 class MarkdownActivity {
-  constructor (quillJS, options) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.options = options
     this.quillJS.on('text-change', this.onTextChange.bind(this))
@@ -16,7 +16,7 @@ class MarkdownActivity {
       tilde: '~',
       underscore: '_'
     }
-    this.ignoreTags = options.ignoreTags || ['PRE']
+    this.ignoreTags = ['PRE', ...(options.ignoreTags || [])]
     this.tags = new TagsOperators(this.quillJS, options.tags)
     this.matches = this.tags.getOperatorsAll()
     this.fullMatches = this.tags.getFullTextOperatorsAll()

--- a/src/tags/blockquote/fulltext.js
+++ b/src/tags/blockquote/fulltext.js
@@ -1,8 +1,8 @@
 class Blockquote {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'blockquote'
-    this.pattern = /^\s{0,99}(>)\s/g
+    this.pattern = options.pattern || /^\s{0,99}(>)\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/blockquote/index.js
+++ b/src/tags/blockquote/index.js
@@ -1,8 +1,8 @@
 class Blockquote {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'blockquote'
-    this.pattern = /^(>)\s/g
+    this.pattern = options.pattern || /^(>)\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/bold/index.js
+++ b/src/tags/bold/index.js
@@ -1,8 +1,8 @@
 class Bold {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'bold'
-    this.pattern = /(\*|_){2}(.+?)(?:\1){2}/g
+    this.pattern = options.pattern || /(\*|_){2}(.+?)(?:\1){2}/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/checkbox/fulltext-checked.js
+++ b/src/tags/checkbox/fulltext-checked.js
@@ -1,8 +1,8 @@
 class Link {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'checkbox-checked'
-    this.pattern = /^(\[x\])+\s/g
+    this.pattern = options.pattern || /^(\[x\])+\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/checkbox/fulltext-unchecked.js
+++ b/src/tags/checkbox/fulltext-unchecked.js
@@ -1,8 +1,8 @@
 class Link {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'checkbox-unchecked'
-    this.pattern = /^(\[\s?\])+\s/g
+    this.pattern = options.pattern || /^(\[\s?\])+\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/codeblock/fulltext.js
+++ b/src/tags/codeblock/fulltext.js
@@ -1,8 +1,8 @@
 class Codeblock {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'pre'
-    this.pattern = /^(```)/g
+    this.pattern = options.pattern || /^(```)/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/codeblock/index.js
+++ b/src/tags/codeblock/index.js
@@ -1,8 +1,8 @@
 class Codeblock {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'pre'
-    this.pattern = /^(```)\s/g
+    this.pattern = options.pattern || /^(```)\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/header/index.js
+++ b/src/tags/header/index.js
@@ -1,8 +1,8 @@
 class Header {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'header'
-    this.pattern = /^(#){1,6}\s/g
+    this.pattern = options.pattern || /^(#){1,6}\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -16,7 +16,6 @@ import Strikethrough from './strikethrough'
 
 class TagsOperators {
   constructor (quillJS, tags = {}) {
-    console.log('TagsOperators', tags.header)
     this.quillJS = quillJS
     this.getOperatorsAll.bind(this)
     this.tags = [

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -15,33 +15,34 @@ import CodeblockFullText from './codeblock/fulltext'
 import Strikethrough from './strikethrough'
 
 class TagsOperators {
-  constructor (quillJS) {
+  constructor (quillJS, tags = {}) {
+    console.log('TagsOperators', tags.header)
     this.quillJS = quillJS
     this.getOperatorsAll.bind(this)
     this.tags = [
-      new Header(this.quillJS).getAction(),
-      new Blockquote(this.quillJS).getAction(),
-      new Bold(this.quillJS).getAction(),
-      new Link(this.quillJS).getAction(),
-      new Codeblock(this.quillJS).getAction(),
-      new InlineCode(this.quillJS).getAction(),
-      new Strikethrough(this.quillJS).getAction(),
-      new Italics(this.quillJS).getAction()
+      new Header(this.quillJS, tags.header).getAction(),
+      new Blockquote(this.quillJS, tags.blockquote).getAction(),
+      new Bold(this.quillJS, tags.bold).getAction(),
+      new Link(this.quillJS, tags.link).getAction(),
+      new Codeblock(this.quillJS, tags.codeblock).getAction(),
+      new InlineCode(this.quillJS, tags.inlinecode).getAction(),
+      new Strikethrough(this.quillJS, tags.strikethrough).getAction(),
+      new Italics(this.quillJS, tags.italic).getAction()
     ]
 
     this.fullTextTags = [
-      new Header(this.quillJS).getAction(),
-      new CheckBoxChecked(this.quillJS).getAction(),
-      new CheckBoxUnchecked(this.quillJS).getAction(),
-      new ListOfNumberFulltext(this.quillJS).getAction(),
-      new ListOfBulletFulltext(this.quillJS).getAction(),
-      new BlockquoteFulltext(this.quillJS).getAction(),
-      new CodeblockFullText(this.quillJS).getAction(),
-      new Bold(this.quillJS).getAction(),
-      new LinkFullText(this.quillJS).getAction(),
-      new InlineCode(this.quillJS).getAction(),
-      new Strikethrough(this.quillJS).getAction(),
-      new Italics(this.quillJS).getAction()
+      new Header(this.quillJS, tags.header).getAction(),
+      new CheckBoxChecked(this.quillJS, tags.checkBoxChecked).getAction(),
+      new CheckBoxUnchecked(this.quillJS, tags.checkBoxUnchecked).getAction(),
+      new ListOfNumberFulltext(this.quillJS, tags.listOfNumberFulltext).getAction(),
+      new ListOfBulletFulltext(this.quillJS, tags.listOfBulletFulltext).getAction(),
+      new BlockquoteFulltext(this.quillJS, tags.blockquote).getAction(),
+      new CodeblockFullText(this.quillJS, tags.codeblock).getAction(),
+      new Bold(this.quillJS, tags.bold).getAction(),
+      new LinkFullText(this.quillJS, tags.link).getAction(),
+      new InlineCode(this.quillJS, tags.inlinecode).getAction(),
+      new Strikethrough(this.quillJS, tags.strikethrough).getAction(),
+      new Italics(this.quillJS, tags.italic).getAction()
     ]
   }
 

--- a/src/tags/inlinecode/index.js
+++ b/src/tags/inlinecode/index.js
@@ -1,8 +1,8 @@
 class inlineCode {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'code'
-    this.pattern = /(`){1}(.+?)(`){1}/g
+    this.pattern = options.pattern || /(`){1}(.+?)(`){1}/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/italics/index.js
+++ b/src/tags/italics/index.js
@@ -1,8 +1,9 @@
 class Bold {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'italic'
-    this.pattern = /(\*|_){1}(.+?)(?:\1){1}/g
+    this.pattern = options.pattern || /(\*|_){1}(.+?)(?:\1){1}/g
+    console.log('Italic', this.pattern);
     this.getAction.bind(this)
   }
 

--- a/src/tags/italics/index.js
+++ b/src/tags/italics/index.js
@@ -3,7 +3,6 @@ class Bold {
     this.quillJS = quillJS
     this.name = 'italic'
     this.pattern = options.pattern || /(\*|_){1}(.+?)(?:\1){1}/g
-    console.log('Italic', this.pattern);
     this.getAction.bind(this)
   }
 

--- a/src/tags/link/fulltext.js
+++ b/src/tags/link/fulltext.js
@@ -1,8 +1,8 @@
 class Link {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'link'
-    this.pattern = /(?:\[(.+?)\])(?:\((.+?)\))/g
+    this.pattern = options.pattern || /(?:\[(.+?)\])(?:\((.+?)\))/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/link/index.js
+++ b/src/tags/link/index.js
@@ -1,8 +1,8 @@
 class Link {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'link'
-    this.pattern = /(?:\[(.+?)\])(?:\((.+?)\))/g
+    this.pattern = options.pattern || /(?:\[(.+?)\])(?:\((.+?)\))/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/listb/fulltext.js
+++ b/src/tags/listb/fulltext.js
@@ -1,8 +1,8 @@
 class Link {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'list'
-    this.pattern = /^\s{0,9}(-|\*){1}\s/
+    this.pattern = options.pattern || /^\s{0,9}(-|\*){1}\s/
     this.getAction.bind(this)
   }
 

--- a/src/tags/listn/fulltext.js
+++ b/src/tags/listn/fulltext.js
@@ -1,8 +1,8 @@
 class Link {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'list'
-    this.pattern = /^\s{0,9}(\d)+\.\s/g
+    this.pattern = options.pattern || /^\s{0,9}(\d)+\.\s/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/strikethrough/index.js
+++ b/src/tags/strikethrough/index.js
@@ -2,7 +2,7 @@ class Bold {
   constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'strikethrough'
-    this.pattern =  options.pattern || /(?:~|_){2}(.+?)(?:~|_){2}/g
+    this.pattern = options.pattern || /(?:~|_){2}(.+?)(?:~|_){2}/g
     this.getAction.bind(this)
   }
 

--- a/src/tags/strikethrough/index.js
+++ b/src/tags/strikethrough/index.js
@@ -1,8 +1,8 @@
 class Bold {
-  constructor (quillJS) {
+  constructor (quillJS, options = {}) {
     this.quillJS = quillJS
     this.name = 'strikethrough'
-    this.pattern = /(?:~|_){2}(.+?)(?:~|_){2}/g
+    this.pattern =  options.pattern || /(?:~|_){2}(.+?)(?:~|_){2}/g
     this.getAction.bind(this)
   }
 


### PR DESCRIPTION
Allow change regex patterns and ignore tags with option param.

Example:
```
this.editor = new Quill('#editor', options);

const markdownOptions = {
  ignoreTags: ['H1', 'H2'],
  tags: {
    bold: {
      pattern: /(\*){1}(.+?)(?:\1){1}/g,
    },
    italic: {
      pattern: /(\_){1}(.+?)(?:\1){1}/g,
    },
  },
};
const markdown = new QuillMarkdown(this.editor, markdownOptions);
```
