### PR TITLE
+ issue-57 fixed bug - cannot execute link on editor inline mode

### DIFF
--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -6,6 +6,7 @@ import CheckBoxChecked from './checkbox/fulltext-checked'
 import CheckBoxUnchecked from './checkbox/fulltext-unchecked'
 import InlineCode from './inlinecode'
 import Italics from './italics'
+import Link from './link'
 import LinkFullText from './link/fulltext'
 import ListOfNumberFulltext from './listn/fulltext'
 import ListOfBulletFulltext from './listb/fulltext'
@@ -24,7 +25,8 @@ class TagsOperators {
       new Codeblock(this.quillJS, options).getAction(),
       new InlineCode(this.quillJS, options).getAction(),
       new Strikethrough(this.quillJS, options).getAction(),
-      new Italics(this.quillJS, options).getAction()
+      new Italics(this.quillJS, options).getAction(),
+      new Link(this.quillJS, options).getAction()
     ]
 
     this.supportfullTextTags = [

--- a/src/tags/link/index.js
+++ b/src/tags/link/index.js
@@ -1,0 +1,47 @@
+import AbstractTag from '../AbstractTag'
+import meta from './meta'
+
+class Link extends AbstractTag {
+  constructor (quillJS, options = {}) {
+    super()
+    this.quillJS = quillJS
+    this.name = 'link'
+    this.pattern = this._getCustomPatternOrDefault(options, this.name, /(?:\[(.+?)\])(?:\((.+?)\))/g)
+    this.getAction.bind(this)
+    this._meta = meta()
+    this.activeTags = this._getActiveTagsWithoutIgnore(this._meta.applyHtmlTags, options.ignoreTags)
+  }
+
+  getAction () {
+    return {
+      name: this.name,
+      pattern: this.pattern,
+      action: (text, selection, pattern, lineStart) => new Promise((resolve) => {
+        const match = pattern.exec(text)
+        const startIndex = lineStart + match.index
+        const linkStartIndex = text.search(pattern)
+        const matchedText = text.match(pattern)[0]
+        const hrefText = text.match(/(?:\[(.*?)\])/g)[0]
+        const hrefLink = text.match(/(?:\((.*?)\))/g)[0]
+        if (!this.activeTags.length) {
+          resolve(false)
+          return
+        }
+
+        if (linkStartIndex !== -1) {
+          setTimeout(() => {
+            const removeOffset = startIndex
+            this.quillJS.deleteText(removeOffset, matchedText.length)
+            this.quillJS.insertText(removeOffset, hrefText.slice(1, hrefText.length - 1),
+              'link', hrefLink.slice(1, hrefLink.length - 1))
+            resolve(true)
+          }, 0)
+        } else {
+          resolve(false)
+        }
+      })
+    }
+  }
+}
+
+export default Link


### PR DESCRIPTION
Currently, does not work Link text for inline mode on released version.
This PR resolved problems

Thank you for report @DykiSA

Fixed #57 

## BEFORE (Problem)
![link_problem](https://user-images.githubusercontent.com/10525473/166820160-54af2d11-7b90-49d8-8294-142bd2521832.gif)

.
.
.
.
.
.
.
.
.


## FIXED (On this PR)
![bugfixed_link](https://user-images.githubusercontent.com/10525473/166820320-54de2f8d-af83-4063-b344-f762acfb5e42.gif)

