### PR TITLE
Fix list truncate

### DIFF
--- a/src/tags/listb/fulltext.js
+++ b/src/tags/listb/fulltext.js
@@ -32,9 +32,10 @@ class ListBullet extends AbstractTag {
         const index = this.quillJS.getIndex(line)
 
         setTimeout(() => {
-          let offsetText = /^\s{0,9}(\*){1}\s/.test(text) ? text.replace('*', '-') : text
-          const depth = offsetText.split('- ')[0].split('').filter(e => /\s/gi.test(e)).length
-          const replaceText = text.replace(/^\s*- /, "");
+          const offsetText= text.replace(/^(\s*)\* /, '$1- ');
+          const depth = offsetText.split('-')[0].length
+          const replaceText = offsetText.replace(/^\s*- /, "");
+
           this.quillJS.insertText(index, replaceText)
           this.quillJS.deleteText(index + replaceText.length - 1, text.length)
           setTimeout(() => {

--- a/src/tags/listb/fulltext.js
+++ b/src/tags/listb/fulltext.js
@@ -1,7 +1,7 @@
 import AbstractTag from '../AbstractTag.js'
 import meta from './meta.js'
 
-class Link extends AbstractTag {
+class ListBullet extends AbstractTag {
   constructor (quillJS, options = {}) {
     super()
     this.quillJS = quillJS
@@ -47,4 +47,4 @@ class Link extends AbstractTag {
   }
 }
 
-export default Link
+export default ListBullet

--- a/src/tags/listb/fulltext.js
+++ b/src/tags/listb/fulltext.js
@@ -34,7 +34,7 @@ class ListBullet extends AbstractTag {
         setTimeout(() => {
           let offsetText = /^\s{0,9}(\*){1}\s/.test(text) ? text.replace('*', '-') : text
           const depth = offsetText.split('- ')[0].split('').filter(e => /\s/gi.test(e)).length
-          let replaceText = offsetText.split('- ').length > 1 ? offsetText.split('- ').splice(1, 1).join('') : offsetText
+          const replaceText = text.replace(/^\s*- /, "");
           this.quillJS.insertText(index, replaceText)
           this.quillJS.deleteText(index + replaceText.length - 1, text.length)
           setTimeout(() => {

--- a/src/tags/listn/fulltext.js
+++ b/src/tags/listn/fulltext.js
@@ -1,7 +1,7 @@
 import AbstractTag from '../AbstractTag.js'
 import meta from './meta.js'
 
-class Link extends AbstractTag {
+class ListNumbered extends AbstractTag {
   constructor (quillJS, options = {}) {
     super()
     this.quillJS = quillJS
@@ -26,7 +26,8 @@ class Link extends AbstractTag {
         const index = this.quillJS.getIndex(line)
         setTimeout(() => {
           const depth = text.split('. ')[0].split('').filter(e => /\s/gi.test(e)).length
-          const replaceText = text.split('. ').splice(1, 1).join('')
+          const replaceText = text.replace(/^\s*\d+\. /, "");
+
           this.quillJS.insertText(index, replaceText)
           this.quillJS.deleteText(index + replaceText.length - 1, text.length)
           setTimeout(() => {
@@ -39,4 +40,4 @@ class Link extends AbstractTag {
   }
 }
 
-export default Link
+export default ListNumbered


### PR DESCRIPTION
# Problem

The calculation of `replaceText` produces truncated lists sometimes. For example 

## Numbered lists

The existing approach for numbered lists with `. ` in it

```javascript
"1. Respond to the user to acnowledge their request. Be friendly, supportive, and concise.".split('. ').splice(1, 1).join('')
> 'Respond to the user to acnowledge their request'
```

While the new approach returns

```javascript
"1. Respond to the user to acnowledge their request. Be friendly, supportive, and concise.".replace(/^\s*\d+\. /, "")
> 'Respond to the user to acnowledge their request. Be friendly, supportive, and concise.'
```

## Bullet lists

The existing approach if a `- ` is in the list

```javascript
offsetText = "    - my bullet list with a - in it"
offsetText.split('- ').length > 1 ? offsetText.split('- ').splice(1, 1).join('') : offsetText
> 'my bullet list with a '
```

The updated approach

```javascript
"    - my bullet list with a - in it".replace(/^\s*- /, "");
> 'my bullet list with a - in it'
```